### PR TITLE
Add simple PyQt5 HTML viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # test_Codex
+
+## HTML Viewer
+
+This repository contains `html_viewer.py`, a simple PyQt5 application that
+allows you to sequentially browse HTML files located in the same directory.
+
+### Features
+
+- Displays `.html` files using an embedded browser (`QWebEngineView`).
+- Navigation buttons and arrow keys (left/right) to switch between files.
+- `F11` toggles full-screen mode.
+- `Esc` closes the viewer.
+
+### Usage
+
+1. Install dependencies (PyQt5 and PyQtWebEngine):
+
+   ```bash
+   pip install PyQt5==5.15.7 PyQtWebEngine==5.15.7
+   ```
+
+2. Place `html_viewer.py` in the folder containing your HTML files and run:
+
+   ```bash
+   python3 html_viewer.py
+   ```
+
+The application will start in full-screen mode, showing the first HTML file.
+Use the buttons or arrow keys to navigate through the files.

--- a/html_viewer.py
+++ b/html_viewer.py
@@ -1,0 +1,76 @@
+import sys
+import os
+from PyQt5.QtWidgets import QApplication, QMainWindow, QToolBar, QAction
+from PyQt5.QtWebEngineWidgets import QWebEngineView
+from PyQt5.QtCore import QUrl, Qt
+
+class HtmlBrowser(QMainWindow):
+    def __init__(self, html_files):
+        super().__init__()
+        self.html_files = html_files
+        self.index = 0
+
+        self.view = QWebEngineView()
+        self.setCentralWidget(self.view)
+
+        toolbar = QToolBar()
+        self.addToolBar(toolbar)
+        prev_action = QAction('Prev', self)
+        prev_action.triggered.connect(self.prev_page)
+        toolbar.addAction(prev_action)
+        next_action = QAction('Next', self)
+        next_action.triggered.connect(self.next_page)
+        toolbar.addAction(next_action)
+
+        self.load_page()
+        self.showFullScreen()
+
+    def load_page(self):
+        if not self.html_files:
+            return
+        file_url = QUrl.fromLocalFile(self.html_files[self.index])
+        self.view.load(file_url)
+        self.setWindowTitle(os.path.basename(self.html_files[self.index]))
+
+    def next_page(self):
+        if not self.html_files:
+            return
+        self.index = (self.index + 1) % len(self.html_files)
+        self.load_page()
+
+    def prev_page(self):
+        if not self.html_files:
+            return
+        self.index = (self.index - 1) % len(self.html_files)
+        self.load_page()
+
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key_Right:
+            self.next_page()
+        elif event.key() == Qt.Key_Left:
+            self.prev_page()
+        elif event.key() == Qt.Key_F11:
+            if self.isFullScreen():
+                self.showNormal()
+            else:
+                self.showFullScreen()
+        elif event.key() == Qt.Key_Escape:
+            self.close()
+        else:
+            super().keyPressEvent(event)
+
+
+def main():
+    app = QApplication(sys.argv)
+    html_files = sorted(
+        os.path.abspath(f)
+        for f in os.listdir('.')
+        if f.lower().endswith('.html')
+    )
+    browser = HtmlBrowser(html_files)
+    browser.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create `html_viewer.py` to browse `.html` files with PyQt5
- document features and usage in README

## Testing
- `python3 -m py_compile html_viewer.py`
- `python3 html_viewer.py` *(fails: Qt platform plugin 'xcb' could not load)*

------
https://chatgpt.com/codex/tasks/task_e_68411db9b70c8331b8e690386476afbf